### PR TITLE
Enable conversational history and initial scenario

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,10 +43,10 @@
             </button>
         </form>
 
-        <!-- Container for the API response -->
+        <!-- Container for the conversation -->
         <div id="response-container" class="mt-8 p-6 bg-gray-50 border border-gray-200 rounded-lg whitespace-pre-wrap hidden">
-            <h2 class="text-xl font-semibold text-gray-800 mb-2">AI Response:</h2>
-            <p id="response-text" class="text-gray-700"></p>
+            <h2 class="text-xl font-semibold text-gray-800 mb-2">Conversation:</h2>
+            <div id="chat-log" class="space-y-4"></div>
         </div>
          <!-- Error Message Box -->
         <div id="error-box" class="mt-4 p-4 bg-red-100 border border-red-400 text-red-700 rounded-lg hidden">

--- a/netlify/functions/openai-proxy.js
+++ b/netlify/functions/openai-proxy.js
@@ -47,14 +47,14 @@ exports.handler = async (event) => {
     }
 
     try {
-        // Parse the incoming request body to get the user's prompt
-        const { prompt } = JSON.parse(event.body);
+        // Parse the incoming request body to get the conversation messages
+        const { messages } = JSON.parse(event.body);
 
-        if (!prompt) {
+        if (!messages || !Array.isArray(messages)) {
             return {
                 statusCode: 400,
                 headers,
-                body: JSON.stringify({ error: 'Prompt is required.' }),
+                body: JSON.stringify({ error: 'Messages array is required.' }),
             };
         }
 
@@ -78,7 +78,7 @@ exports.handler = async (event) => {
                 model: 'gpt-4.1',
                 messages: [
                     { role: 'system', content: systemPrompt },
-                    { role: 'user', content: prompt }
+                    ...messages
                 ],
                 max_tokens: 150,
             }),

--- a/script.js
+++ b/script.js
@@ -5,13 +5,48 @@ const submitButton = document.getElementById('submit-button');
 const buttonText = document.getElementById('button-text');
 const spinner = document.getElementById('spinner');
 const responseContainer = document.getElementById('response-container');
-const responseText = document.getElementById('response-text');
+const chatLog = document.getElementById('chat-log');
 const errorBox = document.getElementById('error-box');
 const errorText = document.getElementById('error-text');
+
+// Maintain conversation history
+let messageHistory = [];
+
+function renderChatLog() {
+    chatLog.innerHTML = '';
+    for (const msg of messageHistory) {
+        if (msg.role !== 'system') {
+            const p = document.createElement('p');
+            p.textContent = msg.content;
+            p.className = msg.role === 'user' ? 'text-blue-700 font-medium' : 'text-gray-700';
+            chatLog.appendChild(p);
+        }
+    }
+}
 
 // The URL for your Netlify serverless function.
 // IMPORTANT: This will be the URL of your Netlify site.
 const functionUrl = 'https://unique-gingersnap-b64334.netlify.app/.netlify/functions/openai-proxy';
+
+async function sendMessages() {
+    const response = await fetch(functionUrl, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ messages: messageHistory })
+    });
+
+    if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || `Server responded with status: ${response.status}`);
+    }
+
+    const data = await response.json();
+    messageHistory.push({ role: 'assistant', content: data.reply });
+    renderChatLog();
+    responseContainer.classList.remove('hidden');
+}
 
 // Listen for form submission
 promptForm.addEventListener('submit', async (event) => {
@@ -30,27 +65,9 @@ promptForm.addEventListener('submit', async (event) => {
 
 
     try {
-        // Make a POST request to the serverless function
-        const response = await fetch(functionUrl, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({ prompt: userPrompt }),
-        });
-
-        if (!response.ok) {
-            // Handle HTTP errors like 404 or 500
-            const errorData = await response.json();
-            throw new Error(errorData.error || `Server responded with status: ${response.status}`);
-        }
-
-        const data = await response.json();
-        
-        // Display the response
-        responseText.textContent = data.reply;
-        responseContainer.classList.remove('hidden');
-
+        messageHistory.push({ role: 'user', content: userPrompt });
+        renderChatLog();
+        await sendMessages();
     } catch (error) {
         // Show any errors to the user
         console.error('Error fetching AI response:', error);
@@ -83,3 +100,18 @@ function showError(message) {
 function hideError() {
     errorBox.classList.add('hidden');
 }
+
+// Fetch the initial scenario when the page loads
+window.addEventListener('DOMContentLoaded', async () => {
+    setLoading(true);
+    messageHistory.push({ role: 'user', content: 'Start the first scenario.' });
+    renderChatLog();
+    try {
+        await sendMessages();
+    } catch (error) {
+        console.error('Error fetching initial scenario:', error);
+        showError(error.message);
+    } finally {
+        setLoading(false);
+    }
+});


### PR DESCRIPTION
## Summary
- allow conversation history and scenario initialization
- display full conversation log on the page
- update serverless function to accept message history

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68544ce73f4c832f9763ac10cae8df22