### PR TITLE
Enable conversational history and initial scenario

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,10 +43,11 @@
             </button>
         </form>
 
-        <!-- Container for the API response -->
+        <!-- Container for the conversation -->
         <div id="response-container" class="mt-8 p-6 bg-gray-50 border border-gray-200 rounded-lg whitespace-pre-wrap hidden">
-            <h2 class="text-xl font-semibold text-gray-800 mb-2">AI Response:</h2>
-            <p id="response-text" class="text-gray-700"></p>
+            <h2 class="text-xl font-semibold text-gray-800 mb-2">Conversation:</h2>
+            <div id="chat-log" class="space-y-4"></div>
+            <div id="options-container" class="mt-4 space-y-2"></div>
         </div>
          <!-- Error Message Box -->
         <div id="error-box" class="mt-4 p-4 bg-red-100 border border-red-400 text-red-700 rounded-lg hidden">


### PR DESCRIPTION
## Summary
- allow conversation history and scenario initialization
- display full conversation log on the page
- update serverless function to accept message history
- parse JSON responses and render options for the user

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68544ce73f4c832f9763ac10cae8df22