### PR TITLE
Switch to responses endpoint

### DIFF
--- a/script.js
+++ b/script.js
@@ -29,12 +29,13 @@ function renderChatLog() {
 const functionUrl = 'https://unique-gingersnap-b64334.netlify.app/.netlify/functions/openai-proxy';
 
 async function sendMessages() {
+    const last = messageHistory[messageHistory.length - 1];
     const response = await fetch(functionUrl, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ messages: messageHistory })
+        body: JSON.stringify({ input: last.content })
     });
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary
- use `/v1/responses` endpoint in serverless proxy
- adjust frontend to send last user message as `input`

## Testing
- `node -c netlify/functions/openai-proxy.js`
- `node -c script.js`


------
https://chatgpt.com/codex/tasks/task_e_6854897c2b84832f814a1eb870b74c2d